### PR TITLE
Add cross-compilation release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,18 @@ on: push
 #    types: [created]
 
 jobs:
-  release-linux-amd64:
-    runs-on: ubuntu-latest
+  release:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            extension: dylib
+          - os: ubuntu-latest
+            extension: so
+          - os: windows-latest
+            extension: dll
+    runs-on: ${{ matrix.os }}
+    name: Release ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,28 +35,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: LICENSE ed25519_bip32.h target/release/libed25519_bip32.so
-  release-darwin-amd64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-apple-darwin
-          override: true
-      - name: Install dependencies
-        run: make deps
-      - name: Compile
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --release --target x86_64-apple-darwin
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: LICENSE ed25519_bip32.h target/release/libed25519_bip32.dylib
+          files: LICENSE ed25519_bip32.h target/release/libed25519_bip32.${{ matrix.extension }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,23 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - image: macos-latest
+            name: macos-amd64
             extension: dylib
-          - os: ubuntu-latest
+          - image: ubuntu-latest
+            name: linux-amd64
             extension: so
-          - os: windows-latest
+          - image: windows-latest
+            name: windows-amd64
             extension: dll
-    runs-on: ${{ matrix.os }}
-    name: Release ${{ matrix.os }}
+          - image: [self-hosted, macos, arm64]
+            name: macos-arm64
+            extension: dylib
+          - image: [self-hosted, linux, arm64]
+            name: linux-arm64
+            extension: so
+    runs-on: ${{ matrix.image }}
+    name: Release ${{ matrix.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,6 +40,8 @@ jobs:
         with:
           command: build
           args: --release
+      - name: Generate C Header
+        run: make cheader
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,28 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: LICENSE target/release/libed25519_bip32.so
+          files: LICENSE ed25519_bip32.h target/release/libed25519_bip32.so
+  release-darwin-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-apple-darwin
+          override: true
+      - name: Install dependencies
+        run: make deps
+      - name: Compile
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target x86_64-apple-darwin
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: LICENSE ed25519_bip32.h target/release/libed25519_bip32.dylib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,13 @@ jobs:
           toolchain: stable
       - name: Install dependencies
         run: make deps
+      - name: Regenerate C Header and Check
+        run: make diff
       - name: Compile
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release
-      - name: Generate C Header
-        run: make cheader
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+HEADERFN := ed25519_bip32.h
+
 .PHONY: deps
 deps:
 	cargo install wasm-pack cbindgen
@@ -15,7 +17,13 @@ wasm:
 
 .PHONY: cheader
 cheader:
-	cbindgen -c cbindgen.toml -o ed25519_bip32.h
+	cbindgen -c cbindgen.toml -o $(HEADERFN)
+
+# Regenerate the C Header and complain if it's changed
+.PHONY: diff
+diff: cheader
+	@git diff --name-only --diff-filter=AM --exit-code $(HEADERFN) \
+		|| { echo "C header has changed"; exit 1; }
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Note: I originally tried to do this using the `cross` tool but it turns out that cross-compilation from, say, a Linux host to a Mac target is tricky. It's much easier to compile natively using GH-hosted and self-hosted runners.